### PR TITLE
Basic Card Based Welcome Screen

### DIFF
--- a/packages/frontend/src/welcome/welcome-screen.tsx
+++ b/packages/frontend/src/welcome/welcome-screen.tsx
@@ -1,12 +1,65 @@
 import * as React from 'react'
 
-import {Link} from 'react-router-dom'
+import Button from '@material-ui/core/Button'
+import Card from '@material-ui/core/Card'
+import CardActions from '@material-ui/core/CardActions'
+import CardContent from '@material-ui/core/CardContent'
+import Container from '@material-ui/core/Container'
+import {makeStyles} from '@material-ui/core/styles'
+import {Link as RouterLink} from 'react-router-dom'
 
-export const Welcome = (): JSX.Element => (
-  <div>
-    <h1>Welcome</h1>
-    <Link to="/record">Record a message</Link>
-    <Link to="/messages">Messages</Link>
-    <Link to="/call">Call</Link>
-  </div>
-)
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  card: {
+    flex: 1,
+    margin: '5px',
+  },
+})
+
+export const Welcome = (): JSX.Element => {
+  const classes = useStyles()
+  return (
+    <div>
+      <h1>Welcome</h1>
+      {/* TODO: Warning if configuration missing, link to settings. */}
+      <Container className={classes.container}>
+        <Card className={classes.card}>
+          <CardContent>
+            <h3>Record A Message</h3>
+            <p>Write a transcript, record and save a message to be used in a call.</p>
+          </CardContent>
+          <CardActions>
+            <Button component={RouterLink} to="/record" size="small">
+              Record
+            </Button>
+          </CardActions>
+        </Card>
+        <Card className={classes.card}>
+          <CardContent>
+            <h3>Manage Messages</h3>
+            <p>View, edit, and delete previously recorded messages.</p>
+          </CardContent>
+          <CardActions>
+            <Button component={RouterLink} to="/messages" size="small">
+              View Messages
+            </Button>
+          </CardActions>
+        </Card>
+        <Card className={classes.card}>
+          <CardContent>
+            <h3>Make a Call</h3>
+            <p>Use your configured messages to call a representative.</p>
+          </CardContent>
+          <CardActions>
+            <Button component={RouterLink} to="/call" size="small">
+              Call
+            </Button>
+          </CardActions>
+        </Card>
+      </Container>
+    </div>
+  )
+}

--- a/packages/frontend/src/welcome/welcome-screen.tsx
+++ b/packages/frontend/src/welcome/welcome-screen.tsx
@@ -5,42 +5,74 @@ import Card from '@material-ui/core/Card'
 import CardActions from '@material-ui/core/CardActions'
 import CardContent from '@material-ui/core/CardContent'
 import Container from '@material-ui/core/Container'
-import {makeStyles} from '@material-ui/core/styles'
-import {Link as RouterLink} from 'react-router-dom'
+import Paper from '@material-ui/core/Paper'
+import Typography from '@material-ui/core/Typography'
+import {makeStyles, Theme, createStyles} from '@material-ui/core/styles'
+import {Link as RouterLink, Link} from 'react-router-dom'
 
-const useStyles = makeStyles({
-  container: {
-    display: 'flex',
-    flexDirection: 'row',
-  },
-  card: {
-    flex: 1,
-    margin: '5px',
-  },
-})
+import {useUserSettings} from '../settings/use-user-settings'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    mainContainer: {
+      maxWidth: 750,
+      margin: 'auto',
+    },
+    cardContainer: {
+      marginTop: theme.spacing(4),
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+    settingsContainer: {
+      marginTop: theme.spacing(4),
+      marginLeft: theme.spacing(3),
+      marginRight: theme.spacing(3),
+      padding: theme.spacing(2),
+      backgroundColor: 'hsl(0, 100%, 93%)',
+    },
+    textAlign: {
+      textAlign: 'center',
+    },
+    card: {
+      flex: 1,
+      maxWidth: 300,
+    },
+  }),
+)
+
+const SettingsPrompt = () => {
+  const classes = useStyles()
+  return (
+    <Paper elevation={0} className={classes.settingsContainer}>
+      <Typography variant="h5" className={classes.textAlign}>
+        Configuration Missing!
+      </Typography>
+      <Typography variant="body1" style={{marginTop: 20}}>
+        It looks like this might be your first time using Introvert Activism. You will need to{' '}
+        <Link to="/settings">configure a few settings</Link> before jumping onto calls.
+      </Typography>
+    </Paper>
+  )
+}
 
 export const Welcome = (): JSX.Element => {
   const classes = useStyles()
+  const [settings] = useUserSettings()
+  const settingsNotConfigured = !settings.accessToken || !settings.remoteApiOrigin
+
   return (
-    <div>
-      <h1>Welcome</h1>
-      {/* TODO: Warning if configuration missing, link to settings. */}
-      <Container className={classes.container}>
+    <div className={classes.mainContainer}>
+      {settingsNotConfigured && (
+        <div>
+          <SettingsPrompt />
+        </div>
+      )}
+      <Container className={classes.cardContainer}>
         <Card className={classes.card}>
           <CardContent>
-            <h3>Record A Message</h3>
-            <p>Write a transcript, record and save a message to be used in a call.</p>
-          </CardContent>
-          <CardActions>
-            <Button component={RouterLink} to="/record" size="small">
-              Record
-            </Button>
-          </CardActions>
-        </Card>
-        <Card className={classes.card}>
-          <CardContent>
-            <h3>Manage Messages</h3>
-            <p>View, edit, and delete previously recorded messages.</p>
+            <Typography variant="h5">Manage Messages</Typography>
+            <Typography variant="body1">Create, record, edit, and delete messages.</Typography>
           </CardContent>
           <CardActions>
             <Button component={RouterLink} to="/messages" size="small">
@@ -50,11 +82,13 @@ export const Welcome = (): JSX.Element => {
         </Card>
         <Card className={classes.card}>
           <CardContent>
-            <h3>Make a Call</h3>
-            <p>Use your configured messages to call a representative.</p>
+            <Typography variant="h5">Make A Call</Typography>
+            <Typography variant="body1">
+              Use your configured messages to call a representative.
+            </Typography>
           </CardContent>
           <CardActions>
-            <Button component={RouterLink} to="/call" size="small">
+            <Button component={RouterLink} to="/call" size="small" disabled={settingsNotConfigured}>
               Call
             </Button>
           </CardActions>


### PR DESCRIPTION
Split up the three primary actions of the welcome to be card based. Deduped the first option to manage calls screen. Added a warning when settings are not configured.

I don't necessarily think this is a good design, however it is just an incremental improvement on the current plaintext list.

![image](https://user-images.githubusercontent.com/6392995/84597091-477b5500-ae16-11ea-9234-181e20d1f72e.png)

![image](https://user-images.githubusercontent.com/6392995/84597077-3599b200-ae16-11ea-856e-5034d66a1101.png)



Part of #6 